### PR TITLE
Include impact label family, handle archived repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,10 @@ rules:
     mode: include
     pattern: effort/.*
 
+  - description: Include impact/...
+    mode: include
+    pattern: impact/.*
+
   - description: Include provider/...
     mode: include
     pattern: provider/.*


### PR DESCRIPTION
Two changes:

- For https://github.com/giantswarm/giantswarm/issues/20734 we add the `impact/*` label family.
- The script now handles archived customer repositories gracefully.