### PR TITLE
feat: automate weekly label sync to customer repos

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -1,0 +1,71 @@
+name: Sync labels to customer repos
+
+# Weekly, unattended run of the label sync. Copies labels matching the
+# include rules in config.yaml from the leader repo (giantswarm/giantswarm)
+# to giantswarm/roadmap and every repo listed in
+# giantswarm/giantswarm/data/customers.yaml. Create/update only, never deletes.
+#
+# Hand-authored workflow (not a devctl zz_generated.* file). Do not rename to
+# the zz_generated prefix, or it may be overwritten by repository automation.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the sync plan without applying any changes"
+        type: boolean
+        default: false
+
+# The workflow's own GITHUB_TOKEN needs nothing; cross-repo writes use the
+# App installation token minted below.
+permissions:
+  contents: read
+
+# Never let a manual dispatch race the scheduled run.
+concurrency:
+  group: label-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          # A dedicated giantswarm-label-sync App with:
+          #   - contents: read   on giantswarm/giantswarm (leader labels + customers.yaml)
+          #   - issues:  write   on roadmap + all customer repos (labels live under Issues)
+          # Fallback: swap for the align-files App's ALIGN_FILES_APP_* creds, which
+          # already grant issues:write across installed repos.
+          client-id: ${{ vars.LABEL_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LABEL_SYNC_APP_PRIVATE_KEY }}
+          owner: giantswarm
+          # Empty list = all repositories the App is installed on.
+          repositories: ""
+
+      - name: Synchronize labels
+        env:
+          # cli.py reads the token from this env var, so nothing touches disk.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python cli.py --dry-run
+          else
+            python cli.py --yes
+          fi

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -51,8 +51,6 @@ jobs:
           # A dedicated giantswarm-label-sync App with:
           #   - contents: read   on giantswarm/giantswarm (leader labels + customers.yaml)
           #   - issues:  write   on roadmap + all customer repos (labels live under Issues)
-          # Fallback: swap for the align-files App's ALIGN_FILES_APP_* creds, which
-          # already grant issues:write across installed repos.
           client-id: ${{ vars.LABEL_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.LABEL_SYNC_APP_PRIVATE_KEY }}
           owner: giantswarm

--- a/README.md
+++ b/README.md
@@ -36,3 +36,21 @@ The tool will present you all actions that it _would_ take, then you have to con
 If used with `--dry-run`, no synchronization is happening and no confirmation is requested.
 
 Use the `--conf` option to specify a configuration file path other than the default `./config.yaml`.
+
+## Automated synchronization
+
+Label sync runs automatically once a week (Mondays 06:00 UTC) via the
+`.github/workflows/label-sync.yaml` GitHub Actions workflow, so target repos stay in sync
+without anyone running the container by hand. It authenticates as the dedicated
+`giantswarm-label-sync` GitHub App (installed org-wide, `contents:read` on the leader plus
+`issues:write` on the targets) and runs `cli.py --yes`.
+
+You can also trigger it manually from the **Actions** tab ("Sync labels to customer repos" →
+Run workflow), with a `dry_run` toggle to preview the plan without applying any changes.
+
+### Unattended flags
+
+- `--yes` — apply the plan without the interactive confirmation prompt (for CI / cron runs).
+- `GITHUB_TOKEN` env var — read the token from the environment instead of a `--token-path`
+  file, so unattended runs need not write the secret to disk. `--token-path` still works for
+  local use.

--- a/cli.py
+++ b/cli.py
@@ -1,9 +1,12 @@
 import click
+import os
 import re
 import sys
 
 import github
 import yaml
+
+TOKEN_ENV_VAR = 'GITHUB_TOKEN'
 
 RULE_INCLUDE = 'include'
 RULE_IGNORE = 'ignore'
@@ -23,7 +26,8 @@ class RepoArchivedException(Exception):
 @click.option('--conf', default="./config.yaml", help="Configuration file path.")
 @click.option('--token-path', default="~/.github-token", help="Github token path.")
 @click.option('--dry-run', default=False, is_flag=True, help="Show what you would do, but don't do it.")
-def main(conf, token_path, dry_run):
+@click.option('--yes', default=False, is_flag=True, help="Apply the plan without interactive confirmation (for unattended/CI runs).")
+def main(conf, token_path, dry_run, yes):
     """The main function"""
     config = read_config(conf)
     token = read_token(token_path)
@@ -86,8 +90,9 @@ def main(conf, token_path, dry_run):
         print("Exiting without actions, as --dry-run was used.")
         sys.exit(0)
 
-    response = confirm('Do you want to continue to synchronize labels as described above?')
-    if response == False:
+    if yes:
+        print("Proceeding without confirmation, as --yes was used.")
+    elif confirm('Do you want to continue to synchronize labels as described above?') == False:
         sys.exit(0)
     
     ### Execute sync
@@ -215,7 +220,12 @@ def read_config(path):
 
 
 def read_token(path):
-    with open(path, "r") as input:
+    # Prefer the token from the environment (e.g. an App installation token in CI),
+    # so unattended runs don't need to write the secret to disk. Fall back to the file.
+    env_token = os.environ.get(TOKEN_ENV_VAR)
+    if env_token:
+        return env_token.strip()
+    with open(os.path.expanduser(path), "r") as input:
         token = input.readline()
         return token.strip()
 


### PR DESCRIPTION
Previously the label sync was a manual, interactive `docker run` (last released v0.0.2, 2021) with no scheduled trigger, so target repos drifted out of sync with the leader (giantswarm/giantswarm) even when correctly registered in data/customers.yaml.

- cli.py: add a --yes flag so the sync can run unattended (it otherwise blocks on an interactive Y/N prompt), and read the token from the GITHUB_TOKEN env var so CI need not write the secret to disk.
- Add a weekly scheduled GitHub Actions workflow (label-sync.yaml) that authenticates via a GitHub App installation token and runs the sync. workflow_dispatch supports a dry_run input for manual preview.